### PR TITLE
Doubled each secrete creation sync time to 4s, for a total of 40s.

### DIFF
--- a/api/create.go
+++ b/api/create.go
@@ -42,7 +42,8 @@ func (c *Client) create(name string, template string, cmd *exec.Cmd) (Secret, er
 	// because of the ridiculous way lpass sync works we will need to retry until we get our ID.
 	// see open issue at https://github.com/lastpass/lastpass-cli/issues/450
 	for i := 0; i < 10; i++ {
-		time.Sleep(time.Second * 2)
+        // Still times out we creating several secrets at a time
+		time.Sleep(time.Second * 4) // double the waiting time to 4s per iteration
 		errbuf.Reset()
 		outbuf.Reset()
 		cmd = exec.Command("lpass", "sync")

--- a/docs/data-sources/lastpass_ssh_key.md
+++ b/docs/data-sources/lastpass_ssh_key.md
@@ -1,0 +1,43 @@
+# lastpass_ssh_key Data Source
+
+## Example Usage
+
+```hcl
+locals {
+  mykeys = {
+    one   = "320356527595751118",
+    two   = "1820729297211478707",
+    three = "6859419293998842259",
+    four  = "2454822705972235622",
+  }
+}
+
+data lastpass_ssh_key keys {
+  for_each = local.mykeys
+  id     = each.value
+}
+
+output keys {
+  value = [ for i in data.lastpass_ssh_key.keys : i ]
+}
+```
+
+## Argument Reference
+
+* `id` - (Required) Must be unique numerical value.
+
+## Attribute Reference
+
+* `name`
+* `fullname`
+* `pass_phrase`
+* `public_key`
+* `private_key`
+* `hostname`
+* `bit_strength`
+* `format`
+* `date`
+* `last_modified_gmt`
+* `last_touch`
+* `group`
+* `note`

--- a/docs/resources/lastpass_ssh_key.md
+++ b/docs/resources/lastpass_ssh_key.md
@@ -1,0 +1,48 @@
+# lastpass_server Resource
+
+## Example Usage
+
+```hcl
+resource "lastpass_ssh_key" "mysshkey" {
+    name = "My key"
+    pass_phrase = each.value[1]
+    public_key  = chomp( file("key.pub") )
+    private_key = chomp( file("key.pem") )
+    hostname    = "myserver"
+    note        = <<EOF
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam sed elit nec orci
+cursus rhoncus. Morbi lacus turpis, volutpat in lobortis vel, mattis nec magna.
+Cras gravida libero vitae nisl iaculis ultrices. Fusce odio ligula, pharetra ac
+viverra semper, consequat quis risus.
+EOF
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) Must be unique, and can contain full directory path. Changing name will force recreation.
+* `public_key` - (Required) 
+* `private_key` - (Required) 
+* `pass_phrase` - (Optional)
+* `hostname` - (Optional) 
+* `bit_strength` - (Optional)
+* `format` - (Optional) 
+* `date` - (Optional) 
+* `note` - (Optional)
+
+## Additional ttribute Reference
+
+* `fullname`
+* `last_modified_gmt`
+* `last_touch`
+* `group`
+
+## Importer
+
+Import a pre-existing server secret in Lastpass. Example:
+
+```
+terraform import lastpass_server.mysshkey 4252909269944373577
+```
+
+The ID needs to be a unique numerical value.


### PR DESCRIPTION
Added documentation for lastpass_ssh_key.