### PR TITLE
Increase delay, better error messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=registry.terraform.io
 NAMESPACE=rezroo
 NAME=lastpass
 BINARY=terraform-provider-${NAME}
-VERSION=0.6.0
+VERSION=0.5.5
 OS_ARCH=darwin_amd64
 
 default: install
@@ -26,10 +26,12 @@ release:
 	GOOS=windows GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_windows_amd64
 
 # also cp to root plugins folder to make backward compatible with TF 0.12
-install: build
+install: build ~/.terraform.d/plugins/${BINARY}_v${VERSION}
 	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
-	cp ${BINARY} ~/.terraform.d/plugins/
 	mv ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
+
+~/.terraform.d/plugins/${BINARY}_v${VERSION}: ${BINARY}
+	cp ${BINARY} ~/.terraform.d/plugins/${BINARY}_v${VERSION}
 
 test: 
 	go test -i $(TEST) || exit 1                                                   

--- a/api/create.go
+++ b/api/create.go
@@ -11,15 +11,31 @@ import (
 
 // Create is used to create a new resource and generate ID.
 func (c *Client) Create(s Secret) (Secret, error) {
-    template := s.getTemplate()
-    cmd := exec.Command("lpass", "add", s.Name, "--non-interactive", "--sync=now")
-    return c.create(s.Name, template, cmd)
+	template := s.getTemplate()
+	secrets, err := c.read(s.Name)
+	if err == nil {
+	  // We find a secret by the same name - don't create it again.
+	  // Note: this deviates from default lastpass behavior which allows multiple secrets of the same name
+	  var err = errors.New("Secret " + s.Name + " exists already - try import - aborting")
+	  var secret = secrets[0]
+	  return secret, err
+	}
+	cmd := exec.Command("lpass", "add", s.Name, "--non-interactive", "--sync=now")
+	return c.create(s.Name, template, cmd)
 }
 
 // Create a secret of type node-type
 func (c *Client) CreateNodeType(name string, template string, nodetype string) (Secret, error) {
-    cmd := exec.Command("lpass", "add", name, "--non-interactive", "--sync=now", "--note-type=" + nodetype)
-    return c.create(name, template, cmd)
+	secrets, err := c.read(name)
+	if err == nil {
+	  // We find a secret by the same name - don't create it again.
+	  // Note: this deviates from default lastpass behavior which allows multiple secrets of the same name
+	  var err = errors.New("Secret " + name + " exists already - try import - aborting")
+	  var secret = secrets[0]
+	  return secret, err
+	}
+	cmd := exec.Command("lpass", "add", name, "--non-interactive", "--sync=now", "--note-type=" + nodetype)
+	return c.create(name, template, cmd)
 }
 
 func (c *Client) create(name string, template string, cmd *exec.Cmd) (Secret, error) {
@@ -41,9 +57,18 @@ func (c *Client) create(name string, template string, cmd *exec.Cmd) (Secret, er
 	var secrets []Secret
 	// because of the ridiculous way lpass sync works we will need to retry until we get our ID.
 	// see open issue at https://github.com/lastpass/lastpass-cli/issues/450
-	for i := 0; i < 10; i++ {
-        // Still times out we creating several secrets at a time
-		time.Sleep(time.Second * 4) // double the waiting time to 4s per iteration
+	// 7/22/21: Create continues to timeout during bulk operations, or when client machine is
+	// busy with high CPU/network - for example, when creating 10 secrets, even with terraform
+	// -parallelism=1, we always timeout. The secret is typically eventually created in lastpass
+	// but not registered in the terraform state-file, which will give us an error on the next
+	// try because when we look it up we get two secrets with the same name. I will increase
+	// the timeout retry, and I will disable creation of secrets with the same name.
+	const retry_count = 20 // a number less than infinite, but large enough to not timeout
+	for i := 0; i < retry_count; i++ {
+		// Still times out we creating several secrets at a time
+		// increase wait time between calls from 4s to 30s per iteration to
+		// avoid potential rate-limiting by lastpass server
+		time.Sleep(time.Second * 30)
 		errbuf.Reset()
 		outbuf.Reset()
 		cmd = exec.Command("lpass", "sync")
@@ -53,7 +78,7 @@ func (c *Client) create(name string, template string, cmd *exec.Cmd) (Secret, er
 			var err = errors.New(errbuf.String())
 			return s, err
 		}
-		cmd = exec.Command("lpass", "show", "--sync=now", s.Name, "--json", "-x")
+		cmd = exec.Command("lpass", "show", "--sync=now", "-G", s.Name, "--json", "-x")
 		cmd.Stdout = &outbuf
 		cmd.Stderr = &errbuf
 		err = cmd.Run()
@@ -78,6 +103,6 @@ func (c *Client) create(name string, template string, cmd *exec.Cmd) (Secret, er
 		}
 		return secrets[0], nil
 	}
-	err = errors.New("timeout, unable to create new secret")
+	err = errors.New("timeout, unable to create new secret " + s.Name)
 	return s, err
 }

--- a/api/temp/create.go
+++ b/api/temp/create.go
@@ -1,0 +1,119 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// Create is used to create a new resource and generate ID.
+func (c *Client) Create(s Secret) (Secret, error) {
+    template := s.getTemplate()
+    sec, err := c.ls(s.Name)
+    if err == nil {
+      // We find a secret by the same name - don't create it again.
+      // Note: this deviates from default lastpass behavior which allows multiple secrets of the same name
+      var err = errors.New("Secret" + s.Name + "exists already - aborting")
+      return sec, err
+    }
+    cmd := exec.Command("lpass", "add", s.Name, "--non-interactive", "--sync=now")
+    return c.create(s.Name, template, cmd)
+}
+
+// Create a secret of type node-type
+func (c *Client) CreateNodeType(name string, template string, nodetype string) (Secret, error) {
+    sec, err := c.ls(name)
+    if err == nil {
+      // We find a secret by the same name - don't create it again.
+      // Note: this deviates from default lastpass behavior which allows multiple secrets of the same name
+      var err = errors.New("Secret" + name + "exists already - aborting")
+      return sec, err
+    }
+    cmd := exec.Command("lpass", "add", name, "--non-interactive", "--sync=now", "--note-type=" + nodetype)
+    return c.create(name, template, cmd)
+}
+
+func (c *Client) ls(name string) (Secret, error) {
+	cmd := exec.Command("lpass", "ls", "--sync=auto", "-G", name, "--json", "-x")
+	var outbuf, errbuf bytes.Buffer
+	cmd.Stdout = &outbuf
+	cmd.Stderr = &errbuf
+	err := cmd.Run()
+    var secrets []Secret
+	if err != nil {
+		// Make sure secret does not already exist
+		return secrets[0], nil
+	}
+    err = json.Unmarshal(outbuf.Bytes(), &secrets)
+    return secrets[0], nil
+}
+
+func (c *Client) create(name string, template string, cmd *exec.Cmd) (Secret, error) {
+	var s Secret = Secret{ Name: name }
+	err := c.login()
+	if err != nil {
+		return s, err
+	}
+	var inbuf, errbuf bytes.Buffer
+	inbuf.Write([]byte(template))
+	cmd.Stdin = &inbuf
+	cmd.Stderr = &errbuf
+	err = cmd.Run()
+	if err != nil {
+		var err = errors.New(errbuf.String())
+		return s, err
+	}
+	var outbuf bytes.Buffer
+	var secrets []Secret
+	// because of the ridiculous way lpass sync works we will need to retry until we get our ID.
+	// see open issue at https://github.com/lastpass/lastpass-cli/issues/450
+    // 7/22/21: Create continues to timeout during bulk operations, or when client machine is
+    // busy with high CPU/network - for example, when creating 10 secrets, even with terraform
+    // -parallelism=1, we always timeout. The secret is typically eventually created in lastpass
+    // but not registered in the terraform state-file, which will give us an error on the next
+    // try because when we look it up we get two secrets with the same name. I will increase
+    // the timeout retry, and I will disable creation of secrets with the same name.
+    const retry_count = 25 // a number less than infinite, but large enough to not timeout
+	for i := 0; i < retry_count; i++ {
+        // Still times out we creating several secrets at a time
+		time.Sleep(time.Second * 4) // double the waiting time to 4s per iteration
+		errbuf.Reset()
+		outbuf.Reset()
+		cmd = exec.Command("lpass", "sync")
+		cmd.Stderr = &errbuf
+		err = cmd.Run()
+		if err != nil {
+			var err = errors.New(errbuf.String())
+			return s, err
+		}
+		cmd = exec.Command("lpass", "show", "--sync=now", s.Name, "--json", "-x")
+		cmd.Stdout = &outbuf
+		cmd.Stderr = &errbuf
+		err = cmd.Run()
+		if err != nil {
+			if !strings.Contains(errbuf.String(), "Could not find specified account") {
+				var err = errors.New(errbuf.String())
+				return s, err
+			}
+			continue
+		}
+		err = json.Unmarshal(outbuf.Bytes(), &secrets)
+		if err != nil {
+			return s, err
+		}
+		if len(secrets) > 1 {
+			err := errors.New("more than one secret with same name, unable to determine ID")
+			return s, err
+		}
+		if secrets[0].ID == "0" {
+			// sync is still not done with upstream.
+			continue
+		}
+		return secrets[0], nil
+	}
+	err = errors.New("timeout, unable to create new secret")
+	return s, err
+}

--- a/lastpass/provider.go
+++ b/lastpass/provider.go
@@ -57,8 +57,8 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		if err != nil {
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
-				Summary:  "Unable to create Hashicups client",
-				Detail:   "Unable to auth user for authenticated Hashicups client",
+				Summary:  "Unable to create lastpass client",
+				Detail:   "Unable to auth user '" + client.Username + "' as authenticated lastpass client",
 			})
 			return nil, diags
 		}


### PR DESCRIPTION
- increased delay between lpass calls from 4s to 30s
- increased timeout loop from 10 to 20
- prevent creation of a secret if it already exists
- print name of secret if we timeout
- print username if login fails